### PR TITLE
Upgrade version of webvtt module to fix MalformedCaptionError error

### DIFF
--- a/function_requirements.in
+++ b/function_requirements.in
@@ -2,4 +2,4 @@ requests
 elasticsearch>=6,<7
 elasticsearch-dsl>=6,<7
 aws-lambda-logging
-webvtt-py
+webvtt-py>=0.5.1

--- a/function_requirements.txt
+++ b/function_requirements.txt
@@ -10,8 +10,6 @@ certifi==2024.2.2
     # via requests
 charset-normalizer==3.3.2
     # via requests
-docopt==0.6.2
-    # via webvtt-py
 elasticsearch==6.8.2
     # via
     #   -r function_requirements.in
@@ -32,5 +30,5 @@ urllib3==2.2.1
     # via
     #   elasticsearch
     #   requests
-webvtt-py==0.4.6
+webvtt-py==0.5.1
     # via -r function_requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,10 +30,6 @@ click==8.1.7
     # via ssm-dotenv
 colorama==0.4.4
     # via awscli
-docopt==0.6.2
-    # via
-    #   -r function_requirements.txt
-    #   webvtt-py
 docutils==0.16
     # via awscli
 elasticsearch==6.8.2
@@ -90,5 +86,5 @@ urllib3==2.2.1
     #   botocore
     #   elasticsearch
     #   requests
-webvtt-py==0.4.6
+webvtt-py==0.5.1
     # via -r function_requirements.txt


### PR DESCRIPTION
Fix for PSUPP-3601.
Error is:
[ERROR] MalformedCaptionError: Invalid time format in line 3
Traceback (most recent call last):
  File "/var/task/function.py", line 144, in handler
    for cap in webvtt.read_buffer(buffer):
  File "/var/task/webvtt/webvtt.py", line 68, in read_buffer
    parser = WebVTTParser().read_from_buffer(buffer)
  File "/var/task/webvtt/parsers.py", line 33, in read_from_buffer
    self._parse(content)
  File "/var/task/webvtt/parsers.py", line 214, in _parse
    self._parse_blocks(blocks)
  File "/var/task/webvtt/parsers.py", line 236, in _parse_blocks
    self._parse_blocks(additional_blocks)
  File "/var/task/webvtt/parsers.py", line 232, in _parse_blocks
    caption, additional_blocks = self._parse_cue_block(block)
  File "/var/task/webvtt/parsers.py", line 195, in _parse_cue_block
    raise MalformedCaptionError(